### PR TITLE
Updates to styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
 body {
     margin: 0;
     padding: 0;
-    background-image: url('Main Images/BE Background.jpg');
+    background-image: url('Main Images/BE Background UPSCALED.jpg');
     background-size: cover;
     background-position: center;
     height: 100vh;
@@ -130,10 +130,11 @@ main.content{
 }
 
 .secondary-content-box img {
-    width: 100%;
     border-radius: 10px;
     max-height: 250px;
     min-height: 250px;
+    max-width: 450px;
+    min-width: 450px;
 
 }
 


### PR DESCRIPTION
Added hard limits for width of secondary content to prevent over stretching and maintain uniform appearance. Content boxes around images has been left untouched for now, the stretching of the images was just bothering me.

Linked to an up-scaled background image. Image is much sharper but I am undecided on the look of the tree leaves. Quality of the original image restricts the ability of AI up-scaling to maintain stability of image. May try to use a different up-scaling model in the future.