### PR TITLE
Small CSS styles modifications for stretching and linked new upscaled background

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -132,9 +132,9 @@ main.content{
 .secondary-content-box img {
     border-radius: 10px;
     max-height: 250px;
-    min-height: 250px;
     max-width: 450px;
-    min-width: 450px;
+    width: 100%;
+    height: auto;
 
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
 body {
     margin: 0;
     padding: 0;
-    background-image: url('Main Images/BE Background.jpg');
+    background-image: url('Main Images/BE Background UPSCALED.jpg');
     background-size: cover;
     background-position: center;
     height: 100vh;
@@ -130,10 +130,11 @@ main.content{
 }
 
 .secondary-content-box img {
-    width: 100%;
     border-radius: 10px;
     max-height: 250px;
     min-height: 250px;
+    max-width: 450px;
+    min-width: 450px;
 
 }
 


### PR DESCRIPTION
I used a model I found online to upscale the background photo. Image is sharper but, due to the original image resolution, there is some instability with the leaves on the tree. Unsure if this is better, may use a different model in the future to try and get a better result.

Other changes involve the secondary content images. The changes prevent the images from stretching too far beyond their intended aspect ratio but will also flex with smaller displays or widow sizes. The containers for the images are untouched.

These are small changes as I mainly wanted to re-familiarize myself with GitHub.